### PR TITLE
Actually log in newly created clients

### DIFF
--- a/src/ev-matrix.c
+++ b/src/ev-matrix.c
@@ -210,16 +210,6 @@ on_matrix_open (GObject *object, GAsyncResult *result, gpointer user_data)
   }
   cm_client_set_sync_callback (client, on_client_sync, NULL, NULL);
 
-  cm_client_set_password (client, password);
-  cm_client_set_device_name (client, EV_PROJECT);
-
-  account = cm_client_get_account (client);
-  if (!cm_account_set_login_id (account, username)) {
-    g_critical ("'%s' isn't a valid username", username);
-    ev_quit ();
-    return;
-  }
-
   g_print ("Logging in %s\n", username);
   cm_client_set_enabled (client, TRUE);
   joined_rooms = cm_client_get_joined_rooms (client);

--- a/src/ev-matrix.c
+++ b/src/ev-matrix.c
@@ -202,6 +202,7 @@ on_matrix_open (GObject *object, GAsyncResult *result, gpointer user_data)
   }
 
   g_print ("Logging in %s\n", username);
+  cm_client_set_enabled (client, TRUE);
   joined_rooms = cm_client_get_joined_rooms (client);
 
   g_signal_connect_object (joined_rooms, "items-changed",

--- a/src/ev-matrix.c
+++ b/src/ev-matrix.c
@@ -175,7 +175,8 @@ on_matrix_open (GObject *object, GAsyncResult *result, gpointer user_data)
      * a sync callback for it as it will otherwise assert() */
     if (g_strcmp0 (cm_account_get_login_id (a), username) == 0) {
       client = g_steal_pointer (&c);
-      break;
+    } else {
+      cm_client_set_enabled (c, FALSE);
     }
   }
 

--- a/src/ev-matrix.c
+++ b/src/ev-matrix.c
@@ -180,13 +180,7 @@ on_matrix_open (GObject *object, GAsyncResult *result, gpointer user_data)
   }
 
   if (!client) {
-    /*
-     * FIXME: On first startup libcmatrix will find all matrix accounts
-     * via load_accounts_from_secrets -> cm_secret_store_load_async
-     * independent from the application and will create clients for
-     * them. These will then not have a sync callback set and we crash.
-     */
-    g_warning ("No client yet, creating a new one");
+    g_debug ("No client yet, creating a new one");
     client = cm_matrix_client_new (matrix);
   }
   cm_client_set_sync_callback (client, on_client_sync, NULL, NULL);

--- a/subprojects/libcmatrix.wrap
+++ b/subprojects/libcmatrix.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 directory=libcmatrix
-url=https://source.puri.sm/agx/libcmatrix
-revision=eigenvalue
+url=https://source.puri.sm/Librem5/libcmatrix
+revision=main
 depth=1


### PR DESCRIPTION
See individual commits.

This allows newly created accounts to log in.

However, they will currently not be properly saved into the keyring
and will also create a new device id for each log in