### PR TITLE
ev-matrix: Catch up with CmCallback signature change

### DIFF
--- a/src/ev-matrix.c
+++ b/src/ev-matrix.c
@@ -33,11 +33,11 @@ static GRegex *room_regex;
 
 
 static void
-on_client_sync (gpointer   object,
-                CmClient  *cm_client,
+on_client_sync (CmClient  *cm_client,
                 CmRoom    *room,
                 GPtrArray *events,
-                GError    *err)
+                GError    *err,
+                gpointer  user_data)
 {
   g_debug ("Got new client events");
 

--- a/subprojects/libcmatrix.wrap
+++ b/subprojects/libcmatrix.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 directory=libcmatrix
-url=https://source.puri.sm/Librem5/libcmatrix
-revision=6bc48a9781638dd153b750d37faf19fc6bf47cab
+url=https://source.puri.sm/Librem5/libcmatrix.git
+revision=610563550d612612ada0ef764a36a51d01067b42
 depth=1


### PR DESCRIPTION
Update to work with https://source.puri.sm/Librem5/libcmatrix/-/merge_requests/66